### PR TITLE
updated Recomendations

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,5 +43,5 @@ After enabling Bitlocker, change the model type of the network interface to `vir
 All files for building the initrd can be found in the Linux-Exploit folder.
 
 ## Mitigations that work
-- Use Bitlocker with Pre Boot Authentication (TPM+PIN)
-- Disable UEFI network stack to completely disable PXE
+- Use Bitlocker with Pre Boot Authentication (TPM+PIN) (Preferred way,  since it also prevents a bunch of other attacks against BitLocker.)
+- Apply patch [KB5025885](https://support.microsoft.com/en-us/topic/how-to-manage-the-windows-boot-manager-revocations-for-secure-boot-changes-associated-with-cve-2023-24932-41a975df-beb2-40c1-99a3-b3ff139f832d#bkmk_mitigation_guidelines) as described in the Microsoft guideline.


### PR DESCRIPTION
updated recomendations based upon  https://neodyme.io/en/blog/bitlocker_screwed_without_a_screwdriver/#mitigation as well as other recommendations from that domain

The pin should also prevent against physical attacks such as sniffing the SPI, removed the recommendation to disable the network stack since 
1. it does not protect against downgrading bootmanagers
2. it does not protect against other known forms of attacks against bit locker 
3. UEFI could be reset on the device and renabling the the network stack (net yet tested)
but I have taken the previous reasons enough to remove it and rather advise to either renew their certs or add a pin. With pin being the easier and more secure option for most devices. 