### PR TITLE
Update release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,7 @@
 name: release-initramfs
 
-on:
-  push:
-    # Pattern matched against tags like e.g. v1.0
-    tags:
-      - '*'
+permissions:
+  contents: write
 
 jobs:
   test:
@@ -17,5 +14,6 @@ jobs:
         run: sudo bash ./build.sh
       - name: Release
         uses: softprops/action-gh-release@v2
+        if: github.ref_type == 'tag'
         with:
           files: ./pxe-server/bitpixie-initramfs


### PR DESCRIPTION
The current pipeline outputs

    Found release bitpixie v1.1 (with id=224541147)
    Unexpected error fetching GitHub release for tag refs/tags/v1.1: HttpError: Resource not accessible by integration - https://docs.github.com/rest/releases/releases#update-a-release
    Error: Resource not accessible by integration - https://docs.github.com/rest/releases/releases#update-a-release

This error is known. So, use the recommended solution from an issue [1].

[1] https://github.com/softprops/action-gh-release/issues/572#issuecomment-2586651697