### PR TITLE
Adding list of confirmed vulnerable targets and minor output text error in create-bcd.bat

### DIFF
--- a/pxe-server/Boot/create-bcd.bat
+++ b/pxe-server/Boot/create-bcd.bat
@@ -20,7 +20,7 @@ bcdedit /store BCD_modded /displayorder {%REBOOT_GUID%} /addlast
 
 setlocal
 :PROMPT
-SET /P AREYOUSURE=Do you want to move the file to the SMB server on 10.13.37.1 (Y/[N])?
+SET /P AREYOUSURE=Do you want to move the file to the SMB server on 10.13.37.100 (Y/[N])?
 IF /I "%AREYOUSURE%" NEQ "Y" GOTO END
 
 move BCD_modded S:\BCD

--- a/targets.md
+++ b/targets.md
@@ -1,0 +1,8 @@
+Users of this repo report having successfully exploited this issue on:
+- VMWare Workstation Win 11 and 10 Guests
+- Dell Precision 7510
+- Dell Latitude 3500
+- Dell Latitude 3520
+- Dell XPS 15 9530 p91f
+- Dell XPS P92F
+- HP Elitebook 840 G4


### PR DESCRIPTION
We discussed a while back creating a list of targets users have successfully exploited with this software. I've added one using the devices mentioned in one of the issues.

Additionally, the `create-bcd.bat` script asks if you would like to copy the BCD to `10.13.37.1` but the actual IP address in `start-server.sh` is `10.13.13.100`. This is the same IP address mentioned in the readme. The script doesn't actually use this address as it uses the drive letter, but this change makes output of this script less confusing.